### PR TITLE
Run evaluations in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ cython_debug/
 
 # PyCharm
 .idea
+
+# VS Code
+/.vscode

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ python run_evaluation.py
     --predictions_path [Required]  Path to the predictions file 
     --log_dir          [Required]  Path to directory to save evaluation log files 
     --swe_bench_tasks  [Required]  Path to SWE-bench task instances file or dataset 
+    --namespace        [Optional]  Namespace of the Docker repository 
+    --log_suffix       [Optional]  Suffix to append to log file names
     --skip_existing    [Optional]  Skip evaluating task instances with logs that already exist
     --timeout          [Optional]  Timeout for installation + test script execution
+    --num_processes    [Optional]  Number of processes to run in parallel (-1 for unlimited)
 ```
 
 ### Pull Docker images
@@ -83,7 +86,8 @@ Run a single instance and print logs to stdout.
 ```
 python run_single_instance.py 
     --instance_id      [Required]  Instance ID of the task to run
-    --swe_bench_tasks  [Optional]  Path to SWE-bench task instances file or dataset (default is princeton-nlp/SWE-bench_Lite) 
+    --swe_bench_tasks  [Optional]  Path to SWE-bench task instances file or dataset (default is princeton-nlp/SWE-bench_Lite)
+    --namespace        [Optional]  Namespace of the Docker repository
     --predictions_path [Optional]  Path to the predictions file, if not set the golden patch will be used
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jinja2
 swebench
+datasets

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -58,7 +58,7 @@ async def main(
     log_suffix: str = "",
     skip_existing: bool = False,
     timeout: int = 900,
-    num_processes: int = -1,  # TODO: Implement parallel evaluation
+    num_processes: int = -1,
 ):
     """
     Runs evaluation on predictions for each model/repo/version combination.
@@ -71,6 +71,7 @@ async def main(
         log_suffix (str): Suffix to append to log file names.
         skip_existing (bool): Whether to skip evaluations for predictions that already have logs.
         timeout (int): Timeout for each evaluation.
+        num_processes (int): Number of processes to run in parallel (-1 = unlimited)
 
     Raises:
         ValueError: If log_dir is not a directory, testbed is not a directory, or swe_bench_tasks does not exist.
@@ -143,10 +144,15 @@ async def main(
 
     task_instances = sorted(task_instances, key=lambda x: x[KEY_INSTANCE_ID])
 
+    sem = asyncio.Semaphore(num_processes if num_processes > 0 else len(task_instances))
     async with asyncio.TaskGroup() as tg:
         for task_instance in task_instances:
             if task_instance[KEY_PREDICTION]:
-                tg.create_task(run_docker_evaluation(task_instance, namespace, log_dir, timeout, log_suffix))
+                async def run_docker_throttled(*args, **kwargs):
+                    async with sem:
+                        return await run_docker_evaluation(*args, **kwargs)
+
+                tg.create_task(run_docker_throttled(task_instance, namespace, log_dir, timeout, log_suffix))
             else:
                 logger.info(f"[{task_instance[KEY_INSTANCE_ID]}] No prediction found.")
 
@@ -160,5 +166,6 @@ if __name__ == "__main__":
     parser.add_argument("--log_suffix", type=str, help="(Optional) Suffix to append to log file names", default="")
     parser.add_argument("--skip_existing", action="store_true", help="(Optional) Skip existing logs")
     parser.add_argument("--timeout", type=int, help="(Optional) Timeout in seconds (default: 900)", default=900)
+    parser.add_argument("--num_processes", type=int, help="(Optional) Number of processes to run in parallel (-1 for unlimited)", default=-1)
     args = parser.parse_args()
     asyncio.run(main(**vars(args)))

--- a/swebench_docker/run_docker.py
+++ b/swebench_docker/run_docker.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import logging
@@ -7,7 +8,7 @@ import time
 logger = logging.getLogger(__name__)
 
 
-def run_docker_evaluation(task_instance: dict, namespace: str, log_dir: str, timeout: int = 900, log_suffix: str = ""):
+async def run_docker_evaluation(task_instance: dict, namespace: str, log_dir: str, timeout: int = 900, log_suffix: str = ""):
     repo_name = task_instance['repo'].replace("/", "_")
 
     # Base64 encode the instance JSON to be sure it can be passed as an environment variable
@@ -30,19 +31,25 @@ def run_docker_evaluation(task_instance: dict, namespace: str, log_dir: str, tim
 
     cmd_string = ' '.join(docker_command)
     start_time = time.time()
-    result = subprocess.run(docker_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    process = await asyncio.create_subprocess_shell(cmd_string, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    stdout, stderr = await process.communicate()
+    stdout = stdout.decode()
+    if stderr:
+        stderr = stderr.decode()
+
     elapsed_time = time.time() - start_time
 
-    if result.returncode != 0:
+    if process.returncode != 0:
         logger.warning(
             f"[{task_instance['instance_id']}][{docker_image}]  Error running container:")
         logger.warning(f"Command: {cmd_string}")
-        logger.warning(f"Stdout - {result.stdout}")
-        logger.warning(f"Stderr - {result.stderr}")
+        logger.warning(f"Stdout - {stdout}")
+        logger.warning(f"Stderr - {stderr}")
 
-    elif "Evaluation succeeded" not in result.stdout:
+    elif "Evaluation succeeded" not in stdout:
         logger.warning(f"[{task_instance['instance_id']}][{docker_image}]  Container ran successfully in {elapsed_time} seconds, but evaluation failed.")
         logger.warning(f"Command: {cmd_string}")
-        logger.warning(f"stdout - {result.stdout}")
+        logger.warning(f"stdout - {stdout}")
     else:
         logger.info(f"[{task_instance['instance_id']}][{docker_image}] Container ran successfully in {elapsed_time} seconds.")


### PR DESCRIPTION
Since there are separate docker images for all these test beds, we can run many of them in parallel.

I tested this out on the 23 tasks in swe-bench-lite (dev), and on my machine the running time went from about 1 minute to 13 seconds.

Before (running sequentially)
```
time ~/Code/SWE-bench-data/test.sh
2024-05-07 18:04:00,331 - INFO - # of predictions to evaluate: 23
2024-05-07 18:04:01,970 - INFO - [marshmallow-code__marshmallow-1343][aorwall/swe-bench-marshmallow-code_marshmallow-testbed:2.20] Container ran successfully in 1.6384727954864502 seconds.
2024-05-07 18:04:03,596 - INFO - [marshmallow-code__marshmallow-1359][aorwall/swe-bench-marshmallow-code_marshmallow-testbed:3.0] Container ran successfully in 1.6253280639648438 seconds.
2024-05-07 18:04:07,912 - INFO - [pvlib__pvlib-python-1072][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.7] Container ran successfully in 4.315157890319824 seconds.
2024-05-07 18:04:14,814 - INFO - [pvlib__pvlib-python-1154][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.8] Container ran successfully in 6.9015679359436035 seconds.
2024-05-07 18:04:17,654 - INFO - [pvlib__pvlib-python-1606][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.8] Container ran successfully in 2.8393118381500244 seconds.
2024-05-07 18:04:20,747 - INFO - [pvlib__pvlib-python-1707][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.9] Container ran successfully in 3.0911312103271484 seconds.
2024-05-07 18:04:24,215 - INFO - [pvlib__pvlib-python-1854][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.9] Container ran successfully in 3.466987133026123 seconds.
2024-05-07 18:04:26,083 - INFO - [pydicom__pydicom-1139][aorwall/swe-bench-pydicom_pydicom-testbed:2.0] Container ran successfully in 1.8675169944763184 seconds.
2024-05-07 18:04:28,001 - INFO - [pydicom__pydicom-1256][aorwall/swe-bench-pydicom_pydicom-testbed:2.1] Container ran successfully in 1.9165539741516113 seconds.
2024-05-07 18:04:30,200 - INFO - [pydicom__pydicom-1413][aorwall/swe-bench-pydicom_pydicom-testbed:2.1] Container ran successfully in 2.1983039379119873 seconds.
2024-05-07 18:04:32,163 - INFO - [pydicom__pydicom-1694][aorwall/swe-bench-pydicom_pydicom-testbed:2.3] Container ran successfully in 1.9617500305175781 seconds.
2024-05-07 18:04:34,113 - INFO - [pydicom__pydicom-901][aorwall/swe-bench-pydicom_pydicom-testbed:1.3] Container ran successfully in 1.9479260444641113 seconds.
2024-05-07 18:04:36,020 - INFO - [pylint-dev__astroid-1196][aorwall/swe-bench-pylint-dev_astroid-testbed:2.12] Container ran successfully in 1.9059860706329346 seconds.
2024-05-07 18:04:39,279 - INFO - [pylint-dev__astroid-1268][aorwall/swe-bench-pylint-dev_astroid-testbed:2.9] Container ran successfully in 3.257960081100464 seconds.
2024-05-07 18:04:41,135 - INFO - [pylint-dev__astroid-1333][aorwall/swe-bench-pylint-dev_astroid-testbed:2.10] Container ran successfully in 1.8551418781280518 seconds.
2024-05-07 18:04:42,999 - INFO - [pylint-dev__astroid-1866][aorwall/swe-bench-pylint-dev_astroid-testbed:2.13] Container ran successfully in 1.8630309104919434 seconds.
2024-05-07 18:04:44,957 - INFO - [pylint-dev__astroid-1978][aorwall/swe-bench-pylint-dev_astroid-testbed:2.14] Container ran successfully in 1.9561049938201904 seconds.
2024-05-07 18:04:47,341 - INFO - [pyvista__pyvista-4315][aorwall/swe-bench-pyvista_pyvista-testbed:0.39] Container ran successfully in 2.383140802383423 seconds.
2024-05-07 18:04:50,442 - INFO - [sqlfluff__sqlfluff-1517][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 3.100911855697632 seconds.
2024-05-07 18:04:59,001 - INFO - [sqlfluff__sqlfluff-1625][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 8.55768084526062 seconds.
2024-05-07 18:05:01,436 - INFO - [sqlfluff__sqlfluff-1733][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 2.433339834213257 seconds.
2024-05-07 18:05:05,025 - INFO - [sqlfluff__sqlfluff-1763][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 3.588905096054077 seconds.
2024-05-07 18:05:07,322 - INFO - [sqlfluff__sqlfluff-2419][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.8] Container ran successfully in 2.2959280014038086 seconds.
~/Code/SWE-bench-data/test.sh  4.15s user 1.49s system 8% cpu 1:07.51 total
```
After (running in parallel)
```
time ~/Code/SWE-bench-data/test.sh
2024-05-07 18:07:45,258 - INFO - # of predictions to evaluate: 23
2024-05-07 18:07:48,312 - INFO - [marshmallow-code__marshmallow-1343][aorwall/swe-bench-marshmallow-code_marshmallow-testbed:2.20] Container ran successfully in 3.0527381896972656 seconds.
2024-05-07 18:07:48,776 - INFO - [marshmallow-code__marshmallow-1359][aorwall/swe-bench-marshmallow-code_marshmallow-testbed:3.0] Container ran successfully in 3.514058828353882 seconds.
2024-05-07 18:07:49,604 - INFO - [pydicom__pydicom-1139][aorwall/swe-bench-pydicom_pydicom-testbed:2.0] Container ran successfully in 4.3306190967559814 seconds.
2024-05-07 18:07:49,712 - INFO - [pylint-dev__astroid-1333][aorwall/swe-bench-pylint-dev_astroid-testbed:2.10] Container ran successfully in 4.420519828796387 seconds.
2024-05-07 18:07:49,923 - INFO - [pydicom__pydicom-1256][aorwall/swe-bench-pydicom_pydicom-testbed:2.1] Container ran successfully in 4.647027969360352 seconds.
2024-05-07 18:07:50,076 - INFO - [pylint-dev__astroid-1866][aorwall/swe-bench-pylint-dev_astroid-testbed:2.13] Container ran successfully in 4.770132064819336 seconds.
2024-05-07 18:07:50,203 - INFO - [pylint-dev__astroid-1196][aorwall/swe-bench-pylint-dev_astroid-testbed:2.12] Container ran successfully in 4.918223857879639 seconds.
2024-05-07 18:07:50,320 - INFO - [pydicom__pydicom-901][aorwall/swe-bench-pydicom_pydicom-testbed:1.3] Container ran successfully in 5.03703498840332 seconds.
2024-05-07 18:07:50,358 - INFO - [pydicom__pydicom-1413][aorwall/swe-bench-pydicom_pydicom-testbed:2.1] Container ran successfully in 5.080221176147461 seconds.
2024-05-07 18:07:50,458 - INFO - [pydicom__pydicom-1694][aorwall/swe-bench-pydicom_pydicom-testbed:2.3] Container ran successfully in 5.177462100982666 seconds.
2024-05-07 18:07:50,659 - INFO - [pylint-dev__astroid-1978][aorwall/swe-bench-pylint-dev_astroid-testbed:2.14] Container ran successfully in 5.348940134048462 seconds.
2024-05-07 18:07:50,710 - INFO - [pvlib__pvlib-python-1606][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.8] Container ran successfully in 5.442166090011597 seconds.
2024-05-07 18:07:50,894 - INFO - [sqlfluff__sqlfluff-1733][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 5.573770999908447 seconds.
2024-05-07 18:07:51,210 - INFO - [sqlfluff__sqlfluff-2419][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.8] Container ran successfully in 5.884136915206909 seconds.
2024-05-07 18:07:51,227 - INFO - [pyvista__pyvista-4315][aorwall/swe-bench-pyvista_pyvista-testbed:0.39] Container ran successfully in 5.915223836898804 seconds.
2024-05-07 18:07:51,556 - INFO - [pvlib__pvlib-python-1707][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.9] Container ran successfully in 6.286407232284546 seconds.
2024-05-07 18:07:51,679 - INFO - [sqlfluff__sqlfluff-1517][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 6.3646910190582275 seconds.
2024-05-07 18:07:51,845 - INFO - [pylint-dev__astroid-1268][aorwall/swe-bench-pylint-dev_astroid-testbed:2.9] Container ran successfully in 6.557026624679565 seconds.
2024-05-07 18:07:51,925 - INFO - [pvlib__pvlib-python-1854][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.9] Container ran successfully in 6.653732776641846 seconds.
2024-05-07 18:07:52,501 - INFO - [pvlib__pvlib-python-1072][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.7] Container ran successfully in 7.2378082275390625 seconds.
2024-05-07 18:07:52,748 - INFO - [sqlfluff__sqlfluff-1763][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 7.4257590770721436 seconds.
2024-05-07 18:07:55,584 - INFO - [pvlib__pvlib-python-1154][aorwall/swe-bench-pvlib_pvlib-python-testbed:0.8] Container ran successfully in 10.318269968032837 seconds.
2024-05-07 18:07:57,514 - INFO - [sqlfluff__sqlfluff-1625][aorwall/swe-bench-sqlfluff_sqlfluff-testbed:0.6] Container ran successfully in 12.19603681564331 seconds.
~/Code/SWE-bench-data/test.sh  3.61s user 1.96s system 43% cpu 12.746 total
```