### PR TITLE
Use get_eval_refs from swebench

### DIFF
--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -4,9 +4,10 @@ import os
 from typing import List
 
 from jinja2 import FileSystemLoader, Environment
+from swebench import get_eval_refs
 
 from swebench_docker.constants import MAP_VERSION_TO_INSTALL, MAP_REPO_TO_DEB_PACKAGES
-from swebench_docker.utils import get_eval_refs, get_requirements, get_environment_yml
+from swebench_docker.utils import get_requirements, get_environment_yml
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("build_docker")

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -7,13 +7,15 @@ import hashlib
 import logging
 import os
 
+from swebench import get_eval_refs
+
 from swebench_docker.constants import (
     KEY_INSTANCE_ID,
     KEY_MODEL,
     KEY_PREDICTION, MAP_REPO_TO_TEST_FRAMEWORK,
 )
 from swebench_docker.run_docker import run_docker_evaluation
-from swebench_docker.utils import get_instances, get_eval_refs, get_test_directives
+from swebench_docker.utils import get_instances, get_test_directives
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"

--- a/run_single_instance.py
+++ b/run_single_instance.py
@@ -2,12 +2,12 @@
 
 """Run evaluation"""
 import argparse
-import json
+import asyncio
 import logging
 import os
 import tempfile
 
-from swebench.metrics.getters import get_logs_eval, get_id_from_lp
+from swebench.metrics.getters import get_logs_eval, get_id_from_lp, get_eval_refs
 from swebench.metrics.report import get_eval_report
 
 from swebench_docker.constants import (
@@ -15,7 +15,7 @@ from swebench_docker.constants import (
     KEY_MODEL,
     KEY_PREDICTION, MAP_REPO_TO_TEST_FRAMEWORK, )
 from swebench_docker.run_docker import run_docker_evaluation
-from swebench_docker.utils import get_instances, get_eval_refs, get_test_directives
+from swebench_docker.utils import get_instances, get_test_directives
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -23,7 +23,7 @@ logging.basicConfig(
 logger = logging.getLogger("run_evaluation")
 
 
-def main(
+async def main(
     instance_id: str,
     swe_bench_tasks: str,
     namespace: str,
@@ -75,7 +75,7 @@ def main(
         instance[KEY_MODEL] = "golden"
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        run_docker_evaluation(instance, namespace, temp_dir)
+        await run_docker_evaluation(instance, namespace, temp_dir)
 
         logger.info(f"Instance {instance_id} evaluation logs:")
         eval_log = os.path.join(temp_dir, f"{instance_id}.{instance[KEY_MODEL]}.eval.log")
@@ -117,4 +117,4 @@ if __name__ == "__main__":
     parser.add_argument("--namespace", type=str, help="Docker repository namespace", required=False, default="aorwall")
     parser.add_argument("--predictions_path", type=str, help="Path to predictions file (must be .json)", required=False)
     args = parser.parse_args()
-    main(**vars(args))
+    asyncio.run(main(**vars(args)))

--- a/swebench_docker/utils.py
+++ b/swebench_docker/utils.py
@@ -8,7 +8,7 @@ from swebench_docker.constants import (
     MAP_REPO_TO_REQS_PATHS,
     MAP_REPO_TO_ENV_YML_PATHS,
     SWE_BENCH_URL_RAW,
-    NON_TEST_EXTS, KEY_INSTANCE_ID,
+    NON_TEST_EXTS,
 )
 
 
@@ -429,41 +429,3 @@ def has_attribute_or_import_error(log_before):
         if any([(x in lines_1 or x in lines_2) for x in ['error', 'fail']]):
             return True
     return False
-
-
-
-def get_eval_refs(data_path_or_name):
-    from datasets import load_dataset, load_from_disk
-
-    file_name = data_path_or_name.replace("/", "_")
-    if os.path.isfile(f"{file_name}.json"):
-        with open(f"{file_name}.json", "r") as f:
-            return json.loads(f.read())
-
-    decode_keys = False
-    if os.path.isfile(data_path_or_name):
-        if data_path_or_name.endswith(".jsonl"):
-            data = [json.loads(l) for l in open(data_path_or_name).readlines()]
-        elif data_path_or_name.endswith(".json"):
-            data = json.load(open(data_path_or_name, "r"))
-    elif os.path.isdir(data_path_or_name):
-        data = load_from_disk(data_path_or_name)
-        decode_keys = True
-    else:
-        data = load_dataset(data_path_or_name)
-        decode_keys = True
-    if isinstance(data, dict):
-        all_data = list()
-        for split in data.keys():
-            all_data.extend(data[split])
-        data = all_data
-    if decode_keys:
-        for datum in data:
-            for key in ["PASS_TO_PASS", "FAIL_TO_PASS"]:
-                datum[key] = json.loads(datum[key])
-    d = {d[KEY_INSTANCE_ID]: d for d in data}
-    with open(f"{file_name}.json", "w") as f:
-        f.write(json.dumps(d))
-
-    return d
-


### PR DESCRIPTION
When I run `run_evaluation.py`, a temporary file to cache the dataset is created within the folder. I'm not sure if this was just a thing added for debugging, but it seems not necessary.
- If the file is local, we shouldn't need an extra layer of caching
- If the file is remote (on HuggingFace), the `datasets` package already caches it in `~/.cache/huggingface/datasets`