### PR TITLE
Instance test 2

### DIFF
--- a/run_instance_tests.py
+++ b/run_instance_tests.py
@@ -125,7 +125,7 @@ async def main(
         patch = task["patch"]
         model = "golden"
 
-    output = await run_instance_tests(instance_id, patch, test_directives, model, swe_bench_tasks, namespace, verbose=True)
+    output = await run_instance_tests(instance_id, patch, test_directives, model, swe_bench_tasks, namespace, log_output=True)
     if test_output_dir:
         test_output_dir = os.path.abspath(test_output_dir)
         os.makedirs(os.path.dirname(test_output_dir), exist_ok=True)

--- a/swebench_docker/evaluate_instance.py
+++ b/swebench_docker/evaluate_instance.py
@@ -59,9 +59,11 @@ def main(
             patch_type = PatchType.PATCH_PRED.value
 
         # Run testing script
+        prediction_patch = task_instance[KEY_PREDICTION]
+        test_patch = task_instance["test_patch"]
         if (
-                not tcm.apply_patch(task_instance[KEY_PREDICTION], patch_type=patch_type)
-                or not tcm.apply_patch(task_instance["test_patch"], patch_type=PatchType.PATCH_TEST.value)
+                (prediction_patch and not tcm.apply_patch(prediction_patch, patch_type=patch_type))
+                or (test_patch and not tcm.apply_patch(test_patch, patch_type=PatchType.PATCH_TEST.value))
                 or not tcm.run_tests_task(task_instance)
         ):
             logger.warning("Evaluation failed")


### PR DESCRIPTION
This is a follow-up on #20:
1. Fix a bug with incorrect argument name
2. Allow `task_instance[KEY_PREDICTION]` and `task_instance['test_patch']` to be empty.

I mentioned 2 in the previous PR: In an agent workflow, we want to run tests without a prediction to verify which are valid. We also want to run without a test patch so the agent can evaluate its own edits without 'leaking' any data from the patch.

I'm not sure if modifying `swebench_docker/evaluate_instance.py` requires any other changes, like rebuilding the docker images?