### PR TITLE
bugfix: #28, When saving the file, two lines were accidentally wrapped

### DIFF
--- a/swebench_docker/run_docker.py
+++ b/swebench_docker/run_docker.py
@@ -78,13 +78,11 @@ async def run_docker_evaluation(task_instance: dict, namespace: str, log_dir: st
             logger.warning(f"Stderr - {stderr}")
 
         elif "Evaluation succeeded" not in stdout:
-            logger.warning(f"[{task_instance['instance_id']}][{docker_image}]  Container ran successfully in {
-                           elapsed_time} seconds, but evaluation failed.")
+            logger.warning(f"[{task_instance['instance_id']}][{docker_image}]  Container ran successfully in {elapsed_time} seconds, but evaluation failed.")
             logger.warning(f"Command: {cmd_string}")
             logger.warning(f"stdout - {stdout}")
         else:
-            logger.info(f"[{task_instance['instance_id']}][{
-                        docker_image}] Container ran successfully in {elapsed_time} seconds.")
+            logger.info(f"[{task_instance['instance_id']}][{docker_image}] Container ran successfully in {elapsed_time} seconds.")
     except Exception as e:
         logger.warning(f"[{task_instance['instance_id']}][{docker_image}]  Error running container: {e}")
     finally:


### PR DESCRIPTION
bugfix: #28, When saving the file, two lines were accidentally wrapped by VSCode and will cause errors.
Sorry for my mistake. I didn't check the final saved file when I pasted code to VSCode and saved it. This pr is to fix it.